### PR TITLE
Added an -all flag

### DIFF
--- a/script.sh
+++ b/script.sh
@@ -1,18 +1,54 @@
 #!/bin/bash
 
 usage() {
-  echo "Usage: $0 [-f] [-r] [-m] [-a] [-t] [-p]" 1>&2
-  echo "  -f  Make dnf faster"
-  echo "  -r  Add RPM Fusion"
-  echo "  -m  Add Multimedia Codecs"
-  echo "  -a  Install apps"
-  echo "  -t  Set up adw-gtk3 & dark style"
-  echo "  -p  Add Flathub"
+  echo "Usage: $0 [-all|-f|-r|-m|-a|-t|-p]" 1>&2
+  echo "  -all  Do all flags (f,r,m,a,t,p)"
+  echo "  -f    Make dnf faster"
+  echo "  -r    Add RPM Fusion"
+  echo "  -m    Add Multimedia Codecs"
+  echo "  -a    Install apps"
+  echo "  -t    Set up adw-gtk3 & dark style"
+  echo "  -p    Add Flathub"
   exit 1
 }
 
-while getopts ":frmatp" option; do
+while getopts ":allfrmatp" option; do
   case "${option}" in
+    all)
+      # Do all flags
+      if ! grep -q "^fastestmirror=True" /etc/dnf/dnf.conf; then
+        sh -c 'echo "fastestmirror=True" >> /etc/dnf/dnf.conf'
+      fi
+
+      if ! grep -q "^max_parallel_downloads=10" /etc/dnf/dnf.conf; then
+        sh -c 'echo "max_parallel_downloads=10" >> /etc/dnf/dnf.conf'
+      fi
+
+      if ! grep -q "^defaultyes=True" /etc/dnf/dnf.conf; then
+        sh -c 'echo "defaultyes=True" >> /etc/dnf/dnf.conf'
+      fi
+
+      if ! grep -q "^keepcache=True" /etc/dnf/dnf.conf; then
+        sh -c 'echo "keepcache=True" >> /etc/dnf/dnf.conf'
+      fi
+
+      dnf install https://mirrors.rpmfusion.org/free/fedora/rpmfusion-free-release-$(rpm -E %fedora).noarch.rpm https://mirrors.rpmfusion.org/nonfree/fedora/rpmfusion-nonfree-release-$(rpm -E %fedora).noarch.rpm -y
+
+      dnf groupupdate multimedia --setop="install_weak_deps=False" --exclude=PackageKit-gstreamer-plugin -y
+      dnf groupupdate sound-and-video -y
+
+      dnf install discord -y
+      wget https://download.cdn.viber.com/desktop/Linux/viber.rpm && rpm -i viber.rpm
+      flatpak install flathub com.jetbrains.IntelliJ-IDEA-Community -y
+
+      dnf copr enable nickavem/adw-gtk3 -y
+      dnf install adw-gtk3 -y
+      gsettings set org.gnome.desktop.interface gtk-theme 'adw-gtk3-dark' && gsettings set org.gnome.desktop.interface color-scheme 'prefer-dark'
+
+      flatpak remote-add --if-not-exists flathub https://flathub.org/repo/flathub.flatpakrepo
+      flatpak --user override --filesystem=/home/$USER/.icons/:ro
+      flatpak --user override --filesystem=/usr/share/icons/:ro
+      ;;
     f)
 if ! grep -q "^fastestmirror=True" /etc/dnf/dnf.conf; then
   sh -c 'echo "fastestmirror=True" >> /etc/dnf/dnf.conf'


### PR DESCRIPTION
Right now you have to do `script.sh -f -a -r -m -t -p`. But with this flag you can just `script.sh -all`. It's a pull request becose it wasn't tested yet.